### PR TITLE
Add all MT_game trees to the mapgen.

### DIFF
--- a/games/minetest_game/mods/default/mapgen.lua
+++ b/games/minetest_game/mods/default/mapgen.lua
@@ -934,6 +934,66 @@ function default.register_mgv6_decorations()
 		y_max = 30,
 		decoration = "default:dry_shrub",
 	})
+
+	-- Mynetest: Add all the default trees on mapgen
+
+	-- Aspen tree: everywhere
+	minetest.register_decoration({
+		deco_type = "schematic",
+		place_on = "default:dirt_with_grass",
+		sidelen = 16,
+		noise_params = {
+			offset = 0,
+			scale = 0.003,	-- Tree Density
+			spread = {x=100, y=100, z=100},
+			seed = 25694,
+			octaves = 3,
+			persist = 0.5
+		},
+		y_min = 1,
+		y_max = 31000,
+		schematic = minetest.get_modpath("default").."/schematics/aspen_tree_from_sapling.mts",
+		flags = "place_center_x, place_center_z",
+	})
+
+	-- Acacia tree: lower heights
+	minetest.register_decoration({
+		deco_type = "schematic",
+		place_on = "default:dirt_with_grass",
+		sidelen = 16,
+		noise_params = {
+			offset = 0,
+			scale = 0.002,
+			spread = {x=100, y=100, z=100},
+			seed = 61089,
+			octaves = 3,
+			persist = 0.5
+		},
+		y_min = 1,
+		y_max = 12,
+		schematic = minetest.get_modpath("default").."/schematics/acacia_tree_from_sapling.mts",
+		flags = "place_center_x, place_center_z",
+	})
+
+	-- Pine tree: higher heights
+	minetest.register_decoration({
+		deco_type = "schematic",
+		place_on = "default:dirt_with_grass",
+		sidelen = 16,
+		noise_params = {
+			offset = 0,
+			scale = 0.002,
+			spread = {x=100, y=100, z=100},
+			seed = 24073,
+			octaves = 3,
+			persist = 0.5
+		},
+		y_min = 12,
+		y_max = 31000,
+		schematic = minetest.get_modpath("default").."/schematics/pine_tree_from_sapling.mts",
+		flags = "place_center_x, place_center_z",
+	})
+
 end
 
 -- All mapgens except mgv6 and singlenode


### PR DESCRIPTION
Je crois que c'est la façon la plus efficace de générer tous les arbres de minetest_game :  les enregistrer comme "décorations" v6. Je préfère faire une pull request que modifier directement le dépot parce que ce n'est pas une correction de bug. 

Les valeurs sont arbitraires sauf la densité des arbres ("scale") et leur altitude. J'ai mis les aspens partout, les acacias près du niveau de la mer et les pins en altitude. Sans ces modifications, seuls des pins peuvent exister dans des biomes de neige je pense. C'est testé en local et je pense que tu voudras tester ça aussi en singleplayer.  

En espérant que minetest_game ajoute ces arbres dans la mapgen v6 un jour pour éviter de la maintenance. 